### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The activations do not match exactly, but the final accuracy matches.
 
 ```python
 import jax.numpy as jnp
-from jax_resnet import pretrained_resnest
+from jax_resnet import pretrained_resnet
 
-ResNeSt50, variables = pretrained_resnest(50)
+ResNeSt50, variables = pretrained_resnet(50)
 model = ResNeSt50()
 out = model.apply(variables,
                   jnp.ones((32, 224, 224, 3)),  # ImageNet sized inputs.


### PR DESCRIPTION
The idea here is to change the import in the readme to remove the typo. The spelling now matches:

https://github.com/n2cholas/jax-resnet/blob/43f41194123d63ca5e7d388cab8f85ae5c6d0abf/jax_resnet/pretrained.py#L42

Afterward, pretrained_resnet is imported correctly on my machine.